### PR TITLE
Use terse guard clause for git clone

### DIFF
--- a/infra/build/run.sh
+++ b/infra/build/run.sh
@@ -16,7 +16,7 @@ declare -r _GIT_BRANCH=$(jq -r .GIT_BRANCH <<< "$1")
 declare -r _DOMAIN_NAME='giminiani.com'
 declare -r _TFSTATE_BUCKET_NAME='tfstate-github-pages'
 
-git clone --branch $_GIT_BRANCH $_GIT_REPO
+[ -d "$_PROJECT_NAME" ] || git clone --branch $_GIT_BRANCH $_GIT_REPO
 cd $_PROJECT_NAME
 
 build_application


### PR DESCRIPTION
## Summary
- Add terse guard clause before git clone to prevent errors if directory exists
- Makes the code consistent with other projects (e.g., regex-directed-graph-line-parser)

## Changes
```bash
# Before
git clone --branch $_GIT_BRANCH $_GIT_REPO

# After
[ -d "$_PROJECT_NAME" ] || git clone --branch $_GIT_BRANCH $_GIT_REPO
```

## Test plan
- Build process should work identically
- Guard clause prevents re-cloning if directory exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)