### PR TITLE
Move terraform dep versions to top level projects

### DIFF
--- a/infra/tf/modules/github_pages_core/versions.tf
+++ b/infra/tf/modules/github_pages_core/versions.tf
@@ -2,11 +2,9 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "6.45.0"
     }
     null = {
-      source  = "hashicorp/null"
-      version = "3.2.4"
+      source = "hashicorp/null"
     }
   }
   required_version = ">= 0.13"

--- a/infra/tf/test-env/versions.tf
+++ b/infra/tf/test-env/versions.tf
@@ -4,6 +4,14 @@ terraform {
       source = "hashicorp/aws"
       version = "6.45.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.4"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.9.0"
+    }
   }
   required_version = ">= 1.14.0"
 }

--- a/infra/tf/versions.tf
+++ b/infra/tf/versions.tf
@@ -4,6 +4,10 @@ terraform {
       source = "hashicorp/aws"
       version = "6.45.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.4"
+    }
   }
   required_version = ">= 1.14.0"
 }


### PR DESCRIPTION
This seems like best practice and was also causing issues with renovate
otherwise.

Versions are now specified in the prod and test modules instead of the
shared module.
